### PR TITLE
Corrected path for Go 1.4.x

### DIFF
--- a/gxc/main.go
+++ b/gxc/main.go
@@ -653,7 +653,7 @@ func main() {
 		}
 
 		{
-			file, err := os.Open(filepath.Join(goRoot, "src", "pkg", "runtime"))
+			file, err := os.Open(filepath.Join(goRoot, "pkg"))
 			if err == nil {
 				files, err := file.Readdirnames(-1)
 				if err != nil {


### PR DESCRIPTION
This seems to fix the path problem for Go 1.4.x
